### PR TITLE
Thème sombre selon palette apple dark mode

### DIFF
--- a/MaxPV3/data/graph.html
+++ b/MaxPV3/data/graph.html
@@ -465,7 +465,7 @@
       series: [
         {
           name: 'Facteur de puissance',
-          color: '#000000',
+          color: '#818181',
           data: dataInitChartTempsReel
         }
       ]

--- a/MaxPV3/data/maxpv.css
+++ b/MaxPV3/data/maxpv.css
@@ -57,15 +57,22 @@ body {
 
 @media (prefers-color-scheme: dark) {
     
-body, .accordion-body, rect.highcharts-background, .accordion-button, .bg-light, .table-hover, td, .highcharts-contextmenu > ul {
-    background-color: #0d1117 !important;
-    color: #c9d1d9;
-    fill:#0d1117;
+body,
+.accordion-body,
+.highcharts-background,
+.accordion-button,
+.bg-light,
+.table-hover,
+td,
+.highcharts-contextmenu > ul {
+    background-color: #161618 !important;
+    color: #ffffff;
+    fill:#161618;
     --bs-accordion-inner-border-radius:0;
 }
 
 .highcharts-contextmenu > ul > li {
-    color: #c9d1d9 !important;
+    color: #ffffff !important;
 }
     
 .highcharts-title,
@@ -75,14 +82,12 @@ body, .accordion-body, rect.highcharts-background, .accordion-button, .bg-light,
 .highcharts-caption,
 .highcharts-radial-axis-labels > text,
 .highcharts-tracker > div > span > div {
-    fill: #c9d1d9 !important;
-    color: #c9d1d9;
+    fill: #ffffff !important;
+    color: #ffffff;
 }
 
  .highcharts-tooltip-box {
-    fill: black;
-    fill-opacity: 0.6;
-    stroke-width: 0;
+    fill: #000000;
 }
     
 .highcharts-legend-item > text:hover,
@@ -91,6 +96,6 @@ body, .accordion-body, rect.highcharts-background, .accordion-button, .bg-light,
 }
     
 .highcharts-legend-item-hidden > text {
-    fill: #666666 !important;
+    fill: #818181 !important;
 }
 }


### PR DESCRIPTION
- Ajustements des styles CSS selon la palette de couleur apple dark mode : https://www.color-hex.com/color-palette/99159
- Modification pour rendre compatible avec le thème sombre le graphe du facteur de puissance.